### PR TITLE
TA-1300 fixes for organization and uri tests

### DIFF
--- a/example_suites/global_filters_test_all_types_of_entry.json
+++ b/example_suites/global_filters_test_all_types_of_entry.json
@@ -1591,7 +1591,7 @@
                             },
                             {
                                 "Key":"rule",
-                                "Value":"{\"relation\": \"OR\", \"entries\": [[\"company\", \"ASN9723 iseek Communications Pty Ltd\", \"\"]]}"
+                                "Value":"{\"relation\": \"OR\", \"entries\": [[\"company\", \"iseek Communications Pty Ltd\", \"\"]]}"
                             },
                             {
                                 "Key": "tags",
@@ -2081,7 +2081,7 @@
                             },
                             {
                                 "Key":"rule",
-                                "Value":"{\"relation\": \"OR\", \"entries\": [[\"uri\", \"uri-with-query?a=b\", \"\"]]}"
+                                "Value":"{\"relation\":\"OR\",\"entries\":[[\"uri\",\"uri-with-query\\\\?a=b\",\"k\"]]}"
                             },
                             {
                                 "Key": "tags",
@@ -2130,7 +2130,7 @@
                             },
                             {
                                 "Key":"rule",
-                                "Value":"{\"relation\": \"OR\", \"entries\": [[\"uri\", \"(step17-2|uri-with-regex|step17-3)?a=b\", \"\"]]}"
+                                "Value":"{\"relation\": \"OR\", \"entries\": [[\"uri\", \"(step17-2|uri-with-regex|step17-3)\\\\?a=b\", \"\"]]}"
                             },
                             {
                                 "Key": "tags",


### PR DESCRIPTION
Organization: GF by Organization should use only organization name without AS number.
URI: GF by URI with query string is regex, so the '?' sing should be escaped.